### PR TITLE
Remove 1-frame-per-ant delay when running with display visible

### DIFF
--- a/docs/ant-qoth.js
+++ b/docs/ant-qoth.js
@@ -935,14 +935,21 @@ function abandonGame() {
 
 function processAnts() {
 	processingStartTime = performance.now()
-	for (var t=0; t<batchSize; t++) {
+	var loopLimit = batchSize
+	if (display && continuousMoves) {
+		loopLimit = population.length
+	}
+	for (var t=0; t<loopLimit; t++) {
 		processCurrentAnt()
 		currentAntIndex = (currentAntIndex + 1) % population.length
 		if (currentAntIndex === 0) {
 			moveCounter++
-		}
-		if (moveCounter >= movesPerGame) {
-			break
+			if (moveCounter >= movesPerGame) {
+				break
+			}
+			if (display) {
+				break
+			}
 		}
 	}
 	if (moveCounter === 1) {


### PR DESCRIPTION
Running with the display hidden is currently much faster than running with it visible (even when delay is set to 0), but it's useful to see what's going on to debug things.

This removes the forced 1-frame-per-ant delay which is applied while the display is visible. It does not break the step-ant functionality, and makes no difference to the behaviour when the display is hidden.